### PR TITLE
Fix redirect handling in read_blog_post function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,34 @@ This is a Blog MCP Server built with FastMCP that provides tools for interacting
 
 The back-links.json file contains rich metadata for each blog post. Key functions now return JSON data:
 
+### Top-Level Structure
+
+The back-links.json file has two main sections:
+
+```json
+{
+  "redirects": {
+    "/fortytwo": "/42",
+    "/forty-two": "/42",
+    "/7habits": "/7-habits",
+    // ... mapping of redirect paths to target paths
+  },
+  "url_info": {
+    "/42": { /* post metadata */ },
+    "/about": { /* post metadata */ },
+    // ... one entry per blog post path
+  }
+}
+```
+
+**Important**:
+- The `redirects` field at the top level contains all URL redirects (e.g., `/fortytwo` -> `/42`)
+- The `redirect_url` field inside each `url_info` entry is currently always empty
+- When handling redirects, check the top-level `redirects` field first
+
 ### Available Data Fields
 
-Each blog post in the JSON response includes:
+Each blog post in the `url_info` section includes:
 
 - **title**: Post title
 - **url**: Full blog URL (https://idvork.in/...)
@@ -40,7 +65,9 @@ Each blog post in the JSON response includes:
 - **doc_size**: Document size in characters
 - **markdown_path**: Path to source markdown file (_d/filename.md)
 - **file_path**: Path to generated HTML file (_site/filename.html)
-- **redirect_url**: Any redirect URL for this post
+- **redirect_url**: Currently always empty (use top-level `redirects` instead)
+- **incoming_links**: Array of paths that link to this post
+- **outgoing_links**: Array of paths this post links to
 
 ### JSON Functions
 

--- a/blog_mcp_server.py
+++ b/blog_mcp_server.py
@@ -331,6 +331,7 @@ async def read_blog_post(url: str) -> str:
     try:
         blog_data = await get_blog_data()
         url_info = blog_data.get("url_info", {})
+        redirects = blog_data.get("redirects", {})  # Get top-level redirects
 
         # Handle different URL formats
         if url.startswith("http"):
@@ -371,6 +372,17 @@ async def read_blog_post(url: str) -> str:
                 blog_post = await get_blog_post_by_markdown_path(markdown_path)
                 if blog_post:
                     return format_blog_post(blog_post)
+
+        # Check top-level redirects first
+        if path in redirects:
+            # Found a redirect! Follow it to the target path
+            target_path = redirects[path]
+            if target_path in url_info:
+                markdown_path = url_info[target_path].get("markdown_path", "")
+                if markdown_path:
+                    blog_post = await get_blog_post_by_markdown_path(markdown_path)
+                    if blog_post:
+                        return format_blog_post(blog_post, f"Blog Post (via redirect from {path})")
 
         # Check redirects using back-links data (much faster than downloading all files!)
         # Look through url_info to find any post that redirects to this path

--- a/blog_mcp_server.py
+++ b/blog_mcp_server.py
@@ -384,8 +384,8 @@ async def read_blog_post(url: str) -> str:
                     if blog_post:
                         return format_blog_post(blog_post, f"Blog Post (via redirect from {path})")
 
-        # Check redirects using back-links data (much faster than downloading all files!)
-        # Look through url_info to find any post that redirects to this path
+        # FALLBACK: Check deprecated redirect_url in url_info (for backward compatibility)
+        # TODO: This can be removed in a future update when all redirects are moved to top-level 'redirects'
         for url_path, info in url_info.items():
             redirect_url = info.get("redirect_url", "")
             if redirect_url and (redirect_url == path or redirect_url == path.lstrip("/")):
@@ -394,7 +394,12 @@ async def read_blog_post(url: str) -> str:
                 if markdown_path:
                     blog_post = await get_blog_post_by_markdown_path(markdown_path)
                     if blog_post:
-                        return format_blog_post(blog_post, f"Blog Post (via redirect from {path})")
+                        return format_blog_post(blog_post, f"Blog Post (via deprecated redirect from {path})")
+
+        # Future improvements:
+        # - Consider implementing recursive redirect resolution with depth limit
+        # - Add case-insensitive redirect matching
+        # - Implement more detailed error logging for failed redirects
 
         return f"Blog post not found for: {url}"
 


### PR DESCRIPTION
## Summary
- Fixed redirect handling to check the correct field in back-links.json
- Updated documentation to clarify the JSON structure
- All previously failing E2E tests now pass

## Problem
The production E2E tests were failing with 3 errors:
1. `test_read_blog_post_with_redirect` - Expected `/fortytwo` to redirect to `/42`
2. `test_read_blog_post_all_formats` - Same redirect issue
3. `test_get_recent_changes_with_diff` - Path validation issue (already fixed on production)

## Root Cause Analysis
After investigating the `back-links.json` structure, I discovered it has two separate locations for redirect information:

1. **Top-level `redirects` field** - Contains actual redirect mappings:
   ```json
   {
     "redirects": {
       "/fortytwo": "/42",
       "/forty-two": "/42",
       ...
     }
   }
   ```

2. **`redirect_url` inside `url_info` entries** - Always empty:
   ```json
   {
     "url_info": {
       "/42": {
         "redirect_url": "",  // Always empty!
         ...
       }
     }
   }
   ```

The bug: The code was ONLY checking the empty `redirect_url` fields and ignoring the actual `redirects` field.

## Solution
- Added code to read and check the top-level `redirects` field first
- Falls back to checking `url_info` redirects if needed (though they're currently empty)
- Updated CLAUDE.md to document this JSON structure for future developers

## Test Results
All tests pass locally:
- ✅ `test_read_blog_post_with_redirect` 
- ✅ `test_read_blog_post_all_formats`
- ✅ `test_get_recent_changes_with_diff`

🤖 Generated with [Claude Code](https://claude.ai/code)