### PR TITLE
Enable wildcard repo access by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,25 @@
 # Blog MCP Server Configuration
 # Copy this file to .env and customize as needed
 
+# GitHub Configuration
+# GitHub user or organization name (default: idvorkin)
+GITHUB_REPO_OWNER=idvorkin
+
+# Repository specification (default: idvorkin.github.io)
+# - Single repo: "idvorkin.github.io"
+# - Multiple repos: "repo1,repo2,repo3" (comma-separated)
+# - All repos: "*" (enables access to all public repos)
+GITHUB_REPOS=*
+
+# Default repository when none specified (default: idvorkin.github.io)
+# This is the blog repo that will be used when no repo parameter is provided
+DEFAULT_REPO=idvorkin.github.io
+
+# Path to back-links.json file in each repo (default: back-links.json)
+BACKLINKS_PATH=back-links.json
+
 # Base URL for the blog (default: https://idvork.in)
-BLOG_BASE_URL=https://idvork.in
+BLOG_URL=https://idvork.in
 
 # Request timeout in seconds (default: 30)
 REQUEST_TIMEOUT=30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,47 @@
 
 This is a Blog MCP Server built with FastMCP that provides tools for interacting with Igor's blog.
 
+## Configuration
+
+The server supports multi-repository access via environment variables. See `.env.example` for all configuration options.
+
+### Multi-Repository Support
+
+Configure repository access using these environment variables:
+
+- **GITHUB_REPO_OWNER**: GitHub username or organization (default: `idvorkin`)
+- **GITHUB_REPOS**: Repository specification
+  - Single repo: `"idvorkin.github.io"`
+  - Multiple repos: `"repo1,repo2,repo3"` (comma-separated)
+  - All repos: `"*"` (wildcard - enables access to all public repos)
+- **DEFAULT_REPO**: Default repository when none specified (default: `idvorkin.github.io`)
+  - This is the blog repo used for all tools when no `repo` parameter is provided
+- **BACKLINKS_PATH**: Path to back-links.json in each repo (default: `back-links.json`)
+- **BLOG_URL**: Public blog URL (default: `https://idvork.in`)
+
+### Recommended Configuration
+
+For Igor's setup (blog as default, access to all repos):
+
+```bash
+GITHUB_REPO_OWNER=idvorkin
+GITHUB_REPOS=*
+DEFAULT_REPO=idvorkin.github.io
+BLOG_URL=https://idvork.in
+```
+
+This configuration:
+- Sets `idvorkin.github.io` as the default blog repository
+- Enables searching across all repositories under the `idvorkin` account
+- All tools default to the blog repo unless explicitly given a different repo parameter
+
+### Using Multi-Repo Features
+
+All tools accept an optional `repo` parameter:
+- `blog_search("python", repo="my-other-repo")` - Search in specific repo
+- `blog_search("python")` - Defaults to DEFAULT_REPO (idvorkin.github.io)
+- `list_repos()` - Shows all available repositories
+
 ## FastMCP Architecture
 
 - Uses `@mcp.tool` decorators to automatically expose functions as MCP tools

--- a/blog_mcp_server.py
+++ b/blog_mcp_server.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 # GITHUB_REPO_OWNER: GitHub user/org name (default: "idvorkin")
 #   Example: GITHUB_REPO_OWNER="myorg"
 #
-# GITHUB_REPOS: Repository specification (default: "idvorkin.github.io")
+# GITHUB_REPOS: Repository specification (default: "*")
 #   - Single repo: "idvorkin.github.io"
 #   - Multiple repos: "repo1,repo2,repo3" (comma-separated, whitespace trimmed)
 #   - All user repos: "*" (fetches all public repos via GitHub API)
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 GITHUB_REPO_OWNER = os.getenv("GITHUB_REPO_OWNER", "idvorkin")
-GITHUB_REPOS = os.getenv("GITHUB_REPOS", "idvorkin.github.io")
+GITHUB_REPOS = os.getenv("GITHUB_REPOS", "*")
 DEFAULT_REPO = os.getenv("DEFAULT_REPO", "idvorkin.github.io")
 BLOG_URL = os.getenv("BLOG_URL", "https://idvork.in")
 BACKLINKS_PATH = os.getenv("BACKLINKS_PATH", "back-links.json")


### PR DESCRIPTION
## Summary
- Changed default `GITHUB_REPOS` configuration from `"idvorkin.github.io"` to `"*"`
- Enables access to all repositories under the idvorkin account by default
- Maintains `idvorkin.github.io` as the default blog repository

## Changes Made
- **blog_mcp_server.py**: Updated `GITHUB_REPOS` default value to `"*"`
- **.env.example**: Added comprehensive multi-repository configuration documentation
- **CLAUDE.md**: Added new Configuration section explaining multi-repo setup and usage

## Benefits
- Works out of the box without configuration files
- All repos accessible via optional `repo` parameter
- Blog remains the default for all tools (no breaking changes)
- Better documentation for users who want to customize

## Testing
- ✅ All unit tests pass (`just fast-test`)
- ✅ All multi-repo tests pass (15/15)
- ✅ No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-repository support now enabled by default, allowing access to multiple repositories simultaneously.

* **Documentation**
  * Added comprehensive configuration guide documenting available environment variables and setup options.

* **Chores**
  * Updated default configuration values for improved multi-repository discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->